### PR TITLE
expose settings to disable DRM protection and change background image format

### DIFF
--- a/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
+++ b/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
@@ -83,6 +83,7 @@ Java_com_viliussutkus89_android_pdf2htmlex_pdf2htmlEX_call_1pdf2htmlEX(JNIEnv *e
 
   pdf2htmlEX::pdf2htmlEX converter;
   converter.setProcessOutline(enableOutline == JNI_TRUE);
+  converter.setDRM(false);
   converter.setDataDir(dataDir.c_str());
   converter.setPopplerDataDir(popplerDir.c_str());
   converter.setTMPDir(tmpDir.c_str());

--- a/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
+++ b/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
@@ -73,7 +73,7 @@ Java_com_viliussutkus89_android_pdf2htmlex_pdf2htmlEX_call_1pdf2htmlEX(JNIEnv *e
                                                                jstring userPassword_,
                                                                jboolean enableOutline,
                                                                jboolean enableDrm,
-                                                               jstring backgroundFormat
+                                                               jstring backgroundFormat_
 							       ) {
   CCharGC dataDir(env, dataDir_);
   CCharGC popplerDir(env, popplerDir_);
@@ -82,6 +82,7 @@ Java_com_viliussutkus89_android_pdf2htmlex_pdf2htmlEX_call_1pdf2htmlEX(JNIEnv *e
   CCharGC outputFile(env, outputFile_);
   CCharGC ownerPassword(env, ownerPassword_);
   CCharGC userPassword(env, userPassword_);
+  CCharGC backgroundFormat(env, backgroundFormat_);
 
   pdf2htmlEX::pdf2htmlEX converter;
   converter.setProcessOutline(enableOutline == JNI_TRUE);

--- a/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
+++ b/pdf2htmlEX/src/main/cpp/pdf2htmlEX.cc
@@ -71,7 +71,9 @@ Java_com_viliussutkus89_android_pdf2htmlex_pdf2htmlEX_call_1pdf2htmlEX(JNIEnv *e
                                                                jstring outputFile_,
                                                                jstring ownerPassword_,
                                                                jstring userPassword_,
-							       jboolean enableOutline
+                                                               jboolean enableOutline,
+                                                               jboolean enableDrm,
+                                                               jstring backgroundFormat
 							       ) {
   CCharGC dataDir(env, dataDir_);
   CCharGC popplerDir(env, popplerDir_);
@@ -83,12 +85,16 @@ Java_com_viliussutkus89_android_pdf2htmlex_pdf2htmlEX_call_1pdf2htmlEX(JNIEnv *e
 
   pdf2htmlEX::pdf2htmlEX converter;
   converter.setProcessOutline(enableOutline == JNI_TRUE);
-  converter.setDRM(false);
+  converter.setDRM(enableDrm == JNI_TRUE);
   converter.setDataDir(dataDir.c_str());
   converter.setPopplerDataDir(popplerDir.c_str());
   converter.setTMPDir(tmpDir.c_str());
   converter.setInputFilename(inputFile.c_str());
   converter.setOutputFilename(outputFile.c_str());
+
+  if (!backgroundFormat.isEmpty()) {
+    converter.setBackgroundImageFormat(backgroundFormat.c_str());
+  }
 
   if (!ownerPassword.isEmpty()) {
     converter.setOwnerPassword(ownerPassword.c_str());

--- a/pdf2htmlEX/src/main/java/com/viliussutkus89/android/pdf2htmlex/pdf2htmlEX.java
+++ b/pdf2htmlEX/src/main/java/com/viliussutkus89/android/pdf2htmlex/pdf2htmlEX.java
@@ -186,7 +186,7 @@ public final class pdf2htmlEX {
     return outputHtml;
   }
 
-  private native int call_pdf2htmlEX(String dataDir, String popplerDir, String tmpDir, String inputFile, String outputFile, String ownerPassword, String userPassword, boolean outline);
+  private native int call_pdf2htmlEX(String dataDir, String popplerDir, String tmpDir, String inputFile, String outputFile, String ownerPassword, String userPassword, boolean outline, boolean drm, String backgroundFormat);
 
   // Because Java cannot setenv for the current process
   static native void set_environment_value(String key, String value);

--- a/pdf2htmlEX/src/main/java/com/viliussutkus89/android/pdf2htmlex/pdf2htmlEX.java
+++ b/pdf2htmlEX/src/main/java/com/viliussutkus89/android/pdf2htmlex/pdf2htmlEX.java
@@ -43,6 +43,8 @@ public final class pdf2htmlEX {
   private String p_ownerPassword = "";
   private String p_userPassword = "";
   private boolean p_outline = true;
+  private boolean p_drm = true;
+  private String p_backgroundFormat = "";
 
   public static class ConversionFailedException extends Exception {
     public ConversionFailedException(String errorMessage) {
@@ -162,7 +164,8 @@ public final class pdf2htmlEX {
     Integer retVal = call_pdf2htmlEX(m_pdf2htmlEX_dataDir.getAbsolutePath(),
       m_poppler_dataDir.getAbsolutePath(), m_pdf2htmlEX_tmpDir.getAbsolutePath(),
       this.p_inputPDF.getAbsolutePath(), outputHtml.getAbsolutePath(),
-      this.p_ownerPassword, this.p_userPassword, this.p_outline
+      this.p_ownerPassword, this.p_userPassword, this.p_outline, this.p_drm,
+      this.p_backgroundFormat
     );
 
     // retVal values defined in pdf2htmlEX.cc


### PR DESCRIPTION
documentation says "Turn this on only when you have permission." - we trust our users to own the documents they are attempting to open